### PR TITLE
prefix env variable with STORYBOOK_

### DIFF
--- a/src/panel.tsx
+++ b/src/panel.tsx
@@ -5,7 +5,7 @@ import { styled } from "@storybook/theming";
 import { PARAM_KEY } from "./constants";
 
 const ABSTRACT_APP_URL =
-  process.env.ABSTRACT_APP_URL || "https://app.abstract.com";
+  process.env.STORYBOOK_ABSTRACT_APP_URL || "https://app.abstract.com";
 
 const Iframe = styled.iframe({
   width: "100%",


### PR DESCRIPTION
The prefix is required:
https://storybook.js.org/docs/configurations/env-vars/

This was added to storybook for security reasons, it's something we copied from CRA:
https://create-react-app.dev/docs/adding-custom-environment-variables/