### PR TITLE
fix: Allow parsing of share URLs on abstract.com domain

### DIFF
--- a/src/panel.tsx
+++ b/src/panel.tsx
@@ -14,7 +14,7 @@ const Iframe = styled.iframe({
 });
 
 function parseShareURL(url: string): string | void {
-  return url.split("share.goabstract.com/")[1];
+  return url.split(/share.(?:go)?abstract.com\//)[1];
 }
 
 export function inferShareId(


### PR DESCRIPTION
We recently updated most of our domains to point to the abstract.com domain instead of goabstract.com. This included instances of share links in our Storybook stories. The problem is that this addon doesn't account for the new domain and throws an error when viewing stories that have this addon enabled.

This PR updates the parsing function to account for valid URLs containing the abstract.com domain.