### PR TITLE
Parse url to skip query parameters

### DIFF
--- a/src/panel.tsx
+++ b/src/panel.tsx
@@ -14,7 +14,9 @@ const Iframe = styled.iframe({
 });
 
 function parseShareURL(url: string): string | void {
-  return url.split(/share.(?:go)?abstract.com\//)[1];
+  const parsedUrl = new URL(url);
+  const pathSegments = parsedUrl.pathname.split('/');
+  return pathSegments[pathSegments.length - 1];
 }
 
 export function inferShareId(

--- a/src/panel.tsx
+++ b/src/panel.tsx
@@ -14,9 +14,15 @@ const Iframe = styled.iframe({
 });
 
 function parseShareURL(url: string): string | void {
-  const parsedUrl = new URL(url);
-  const pathSegments = parsedUrl.pathname.split('/');
-  return pathSegments[pathSegments.length - 1];
+  if (url.match(/share.(?:go)?abstract.com\//)) {
+    const parsedUrl = new URL(url);
+    const pathSegments = parsedUrl.pathname.split('/');
+    return pathSegments[pathSegments.length - 1];
+  }
+
+  throw new Error(
+    `The provided url (${url}) is not valid. The url must come from "https://share.abstract.com/" or "https://share.goabstract.com/".`,
+  );
 }
 
 export function inferShareId(


### PR DESCRIPTION
Hey and thank you for a nice and simple solution to our needs!

This PR is more of a proposal and feel free to discard it. But here goes:

The previous version of this plugin ignored the fact that Abstract share urls being provided _might_ contain extra url query parameters. This is sometimes the case when pressing **share** in the Abstract app (e.g. this is what might be copied to the clipboard: https://share.goabstract.com/c23f1aef-57d8-41fd-87db-d32d52f88782?mode=build&sha=0f171110f9b34fdbd691ae11b010f549b8087fef). These query parameters were kept and resulted in a malformed url with multiple query parameters.

By utilizing the URL interface to parse the url we can safely ignore any query parameters passed to the url and only extract the relevant path segment representing the share id.

One of the reasons for adding this is convenience. We might have designers with lesser knowledge of urls doing small changes to the storybooks and adding these urls. In that case I would love for it to just ignore the query parameters.

As far as I can see these query parameters have no effect on the embed url and can be safely discarded. But please tell if you think the should be attached to the resulting embed url as well.